### PR TITLE
update Wikimedia/Wikimedia rule set (upstream patch)

### DIFF
--- a/rules/Wikipedia.xml
+++ b/rules/Wikipedia.xml
@@ -1,13 +1,7 @@
-<!-- www.wikisomething.org is generally a valid
-     domain containing general information on a project and is
-     simply not available at all in HTTPS.  Everything with a /wiki
-     suffix, however, is a language-specific page that is available in
-     HTTPS.  Hence these rules avoid redirecting www.wikisomething.org,
-     while redirecting all language-specific subdomains.  If you
-     navigate first to the WWW page, you could be vulnerable to SSL
-     stripping, but if you succeed in submitting a query from there
-     in a specific language without interference, you'll subsequently
-     be protected.  -->
+<!-- Wikipedia and other Wikimedia Foundation wikis previously had no real HTTPS support, and
+     URLs had to be rewritten to https://secure.wikimedia.org/$wikitype/$language/ . This is no
+     longer the case, see https://blog.wikimedia.org/2011/10/03/native-https-support-enabled-for-all-wikimedia-foundation-wikis/ ,
+     so this file is a lot simpler these days. -->
 
 <ruleset name="Wikipedia">
   <target host="*.wikipedia.org" />
@@ -18,20 +12,37 @@
   <target host="*.wikiversity.org" />
   <target host="*.wiktionary.org" />
   <target host="*.wikimedia.org" />
+  <target host="wikipedia.org" />
+  <target host="wikinews.org" />
+  <target host="wikisource.org" />
+  <target host="wikibooks.org" />
+  <target host="wikiquote.org" />
+  <target host="wikiversity.org" />
+  <target host="wiktionary.org" />
+  <target host="wikimedia.org" />
+  <target host="mediawiki.org" />
+  <target host="www.mediawiki.org" />
+  <target host="wikimediafoundation.org" />
+  <target host="www.wikimediafoundation.org" />
+  <target host="enwp.org" />
+  <target host="frwp.org" />
 
-  <exclusion pattern="^http://www\.wik(ipedia|inews|isource|ibooks|iquote|iversity|tionary)\.org/"/>
-  <rule from="^http://([^@:/]+)\.wik(ipedia|inews|isource|ibooks|iquote|iversity|tionary)\.org/(w|wiki)/"
-          to="https://secure.wikimedia.org/wik$2/$1/$3/"/>
-  <rule from="^http://([^@:/]+)\.wik(ipedia|inews|isource|ibooks|iquote|iversity|tionary)\.org/?$"
-          to="https://secure.wikimedia.org/wik$2/$1/wiki/"/>
+<!-- TODO: What exclusions do we need for mobile sites, if any? -->
+  <exclusion pattern="^http://(dumps|download|svn|noc)\.wikimedia\.org/"/>
+  <exclusion pattern="^http://(static|download|m)\.wikipedia\.org/"/>
 
-  <rule from="^http://(meta|commons|incubator|species|outreach|strategy|usability|wikimania|test|survey)\.wikimedia\.org/wiki/"
-          to="https://secure.wikimedia.org/wikipedia/$1/wiki/"/>
 
-  <rule from="^http://([^@:/]+)\.wik(ipedia|inews|isource|ibooks|iquote|iversity|tionary)\.org/w/index\.php\?title="
-          to="https://secure.wikimedia.org/wik$2/$1/wiki/"/>
+  <rule from="^http://([^@:/]+\.)?wik(ipedia|inews|isource|ibooks|iquote|iversity|tionary|imedia)\.org/"
+          to="https://$1wik$2.org/" />
 
-  <rule from="^http://bugzilla\.wikimedia\.org/"
-          to="https://bugzilla.wikimedia.org/"/>
+  <rule from="^http://(www\.)?mediawiki\.org/"
+	  to="https://$1mediawiki.org/" />
+  <rule from="^http://(www\.)?wikimediafoundation\.org/"
+	  to="https://$1wikimediafoundation.org/" />
 
+  <rule from="^http://enwp\.org/"
+	  to="https://en.wikipedia.org/wiki/" />
+
+  <rule from="^http://frwp\.org/"
+	  to="https://fr.wikipedia.org/wiki/" />
 </ruleset>


### PR DESCRIPTION
This patch comes from upstream HTTPS-Everywhere extension. According
to its git log, authors are:
- Roan Kattouw
- Jérémie Roquet

From the file:

Wikipedia and other Wikimedia Foundation wikis previously had no real
HTTPS support, and URLs had to be rewritten to
https://secure.wikimedia.org/$wikitype/$language/

This is no longer the case, see
https://blog.wikimedia.org/2011/10/03/native-https-support-enabled-for-all-wikim
so this file is a lot simpler these days.
